### PR TITLE
Add HoneyGPT (LLM honeypot, Computer Networks 2026)

### DIFF
--- a/LITERATURES.md
+++ b/LITERATURES.md
@@ -1295,6 +1295,8 @@
 
 56. An LLM-based Framework for Fingerprinting Internet-connected Devices | *ACM on Internet Measurement Conference* | 2023.10.24 | [<u>Paper Link</u>](https://dl.acm.org/doi/pdf/10.1145/3618257.3624845)
 
+57. HoneyGPT: Breaking the Trilemma in Honeypots with Large Language Models | *Computer Networks* | 2026.03.21 | [<u>Paper Link</u>](https://doi.org/10.1016/j.comnet.2026.112223) | [<u>Code</u>](https://github.com/zyw-286/HoneyGPT)
+
 
 <div align="right">
 


### PR DESCRIPTION
Adds **HoneyGPT** to the *Others* section, alongside the existing LLM-honeypot entries (e.g. *LLM in the Shell: Generative Honeypots*).

**HoneyGPT: Breaking the Trilemma in Honeypots with Large Language Models** - Computer Networks, Vol. 282, 2026. DOI: 10.1016/j.comnet.2026.112223

What it contributes over prior LLM honeypots:
- Breaks the honeypot trilemma - flexibility, interaction depth, and deceptive realism at once.
- Real-time attacker-intent analysis with a per-command impact score, logged for ATT&CK-style threat analysis.
- Intent-tailored, stateful responses (system-state register + memory pruning) that stay coherent over long sessions.
- Hybrid emulated/LLM deployment for low cost and fast responses.
- Validated with baseline replay plus a 3-month real-world deployment.

Open-source (BSD-3-Clause, built on Cowrie): https://github.com/zyw-286/HoneyGPT